### PR TITLE
Enable Deletion of Favorites in Settings

### DIFF
--- a/iosChallenge/iosChallenge/Header/BaseViewController.swift
+++ b/iosChallenge/iosChallenge/Header/BaseViewController.swift
@@ -8,8 +8,7 @@
 import UIKit
 import SwiftUI
 
-class BaseViewController: UIViewController {
-
+class BaseViewController: UIViewController, SettingsViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupHeaderView()
@@ -71,9 +70,11 @@ class BaseViewController: UIViewController {
     }
     
     @objc private func settingsButtonTapped() {
-        let settingsView = UIHostingController(rootView: SettingsView())
-        settingsView.modalPresentationStyle = .pageSheet
-        self.present(settingsView, animated: true, completion: nil)
+        var settingsView = SettingsView()
+            settingsView.delegate = self
+            let hostingController = UIHostingController(rootView: settingsView)
+            hostingController.modalPresentationStyle = .pageSheet
+            self.present(hostingController, animated: true, completion: nil)
     }
 
     func setCustomBackButton(title: String) {
@@ -93,5 +94,9 @@ class BaseViewController: UIViewController {
 
     @objc private func backButtonTapped() {
         self.navigationController?.popViewController(animated: true)
+    }
+    
+    func settingsViewDidClose() {
+        // Delegate function
     }
 }

--- a/iosChallenge/iosChallenge/Properties/PropertyDetail/PropertyDetailViewController.swift
+++ b/iosChallenge/iosChallenge/Properties/PropertyDetail/PropertyDetailViewController.swift
@@ -21,6 +21,14 @@ class PropertyDetailViewController: BaseViewController {
         self.setupView()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        self.reloadTable()
+    }
+    
+    override func settingsViewDidClose() {
+        self.reloadTable()
+    }
+    
     func setupView() {
         self.registerCells()
         self.propertyDetailTableView.dataSource = self
@@ -35,6 +43,10 @@ class PropertyDetailViewController: BaseViewController {
         
     }
     
+    func reloadTable() {
+        self.propertyDetailTableView.reloadData()
+    }
+    
 }
 
 // MARK: PropertyDetailViewProtocol
@@ -46,7 +58,7 @@ extension PropertyDetailViewController: PropertyDetailViewProtocol {
     func updateCells(cells: [DetailCellType]) {
         self.cells = cells
         DispatchQueue.main.async{
-            self.propertyDetailTableView.reloadData()
+            self.reloadTable()
         }
     }
     
@@ -55,7 +67,6 @@ extension PropertyDetailViewController: PropertyDetailViewProtocol {
         guard let extraParams = self.extraParams else {return}
         self.presenter?.addPropertyParameters(extraParams: extraParams)
     }
-    
     
 }
 

--- a/iosChallenge/iosChallenge/Properties/PropertyList/PropertyListViewController.swift
+++ b/iosChallenge/iosChallenge/Properties/PropertyList/PropertyListViewController.swift
@@ -25,7 +25,7 @@ class PropertyListViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        self.propertyListTableView.reloadData()
+        self.reloadTable()
     }
     
     
@@ -44,6 +44,14 @@ class PropertyListViewController: BaseViewController {
         self.presenter?.getNewPropertyList()
     }
     
+    override func settingsViewDidClose() {
+        self.reloadTable()
+    }
+    
+    func reloadTable() {
+        self.propertyListTableView.reloadData()
+    }
+    
 }
 
 // MARK: PropertyListViewProtocol
@@ -56,7 +64,7 @@ extension PropertyListViewController: PropertyListViewProtocol {
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
             if reload {
-                self.propertyListTableView.reloadData()
+                self.reloadTable()
             }
             self.refreshControl.endRefreshing()
         }

--- a/iosChallenge/iosChallenge/Settings/SettingsView.swift
+++ b/iosChallenge/iosChallenge/Settings/SettingsView.swift
@@ -7,12 +7,18 @@
 
 import SwiftUI
 
+protocol SettingsViewDelegate: AnyObject {
+    func settingsViewDidClose()
+}
+
 struct SettingsView: View {
     @Environment(\.presentationMode) var presentationMode
     @AppStorage("selectedLanguage") var selectedLanguage = "system"
     @AppStorage("selectedTheme") var selectedTheme = "system"
     @State private var showLanguageAlert = false
     @State private var alertText = ""
+    @State private var favorites = CoreDataManager.shared.getAllFavorites()
+    weak var delegate: SettingsViewDelegate?
     
     var body: some View {
         Group {
@@ -22,6 +28,7 @@ struct SettingsView: View {
                         .navigationBarTitle(Text(Constants.LocalizableKeys.Settings.settings), displayMode: .inline)
                         .navigationBarItems(trailing: Button(action: {
                             presentationMode.wrappedValue.dismiss()
+                            delegate?.settingsViewDidClose()
                         }) {
                             Image(systemName: "xmark")
                                 .foregroundColor(.primary)
@@ -34,6 +41,7 @@ struct SettingsView: View {
                         .navigationBarTitle(Text(Constants.LocalizableKeys.Settings.settings), displayMode: .inline)
                         .navigationBarItems(trailing: Button(action: {
                             presentationMode.wrappedValue.dismiss()
+                            delegate?.settingsViewDidClose()
                         }) {
                             Image(systemName: "xmark")
                                 .foregroundColor(.primary)
@@ -61,11 +69,9 @@ struct SettingsView: View {
             )
         }
     }
-    
+
     var settingsForm: some View {
         Form {
-            let favorites = CoreDataManager.shared.getAllFavorites()
-            
             // MARK: Language
             Section(header: Text(Constants.LocalizableKeys.Settings.language)) {
                 Picker("Select Language", selection: $selectedLanguage) {
@@ -107,7 +113,14 @@ struct SettingsView: View {
                                     .font(.footnote)
                             }
                             Spacer()
-                            Image("favIcon")
+                            Button(action: {
+                                if let propertyCode = favorite.propertyCode {
+                                    CoreDataManager.shared.deleteFavorite(propertyCode: propertyCode)
+                                    favorites = CoreDataManager.shared.getAllFavorites()
+                                }
+                            }) {
+                                Image("favIcon")
+                            }
                         }
                         .padding(.vertical, 5)
                     }


### PR DESCRIPTION
- Added functionality to allow users to delete favorite items directly from the favorites list in the settings screen.
- Updated the UI to include a delete button for each favorite item and connected the button to the CoreDataManager to remove the favorite from persistent storage.